### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "image-size": "^1.0.2",
     "is-url": "^1.2.4",
     "pdfjs-dist": "github:Moebits/pdfjs-dist",
-    "rife-fps": "^0.0.7"
+    "rife-fps": "^0.0.9"
   }
 }


### PR DESCRIPTION
rife-fps 0.0.7 has old package path for gif-frames